### PR TITLE
clean up warnings in selex user-examples

### DIFF
--- a/model_files/selex_age_example/selex_age_example_control.ss
+++ b/model_files/selex_age_example/selex_age_example_control.ss
@@ -86,9 +86,9 @@
  -3 3 1 1 0.8 0 -3 0 0 0 0 0 0 0 # Eggs/kg_inter_Fem_GP_1
  -3 3 0 0 0.8 0 -3 0 0 0 0 0 0 0 # Eggs/kg_slope_wt_Fem_GP_1
 # Sex: 2  BioPattern: 1  NatMort
- 0.05 0.15 0.25 0.1 0.8 0 -3 0 0 0 0 0 0 0 # NatM_uniform_Mal_GP_1
+ 0.05 0.30 0.25 0.1 0.8 0 -3 0 0 0 0 0 0 0 # NatM_uniform_Mal_GP_1
 # Sex: 2  BioPattern: 1  Growth
- 1 45 0 36 10 0 -3 0 0 0 0 0 0 0 # L_at_Amin_Mal_GP_1
+ 0 45 0 36 10 0 -3 0 0 0 0 0 0 0 # L_at_Amin_Mal_GP_1
  40 90 65 70 10 6 -4 0 0 0 0 0 0 0 # L_at_Amax_Mal_GP_1
  0.05 0.25 0.24 0.15 0.8 6 -4 0 0 0 0 0 0 0 # VonBert_K_Mal_GP_1
  0.05 0.25 0.1 0.1 0.8 0 -3 0 0 0 0 0 0 0 # CV_young_Mal_GP_1
@@ -301,7 +301,7 @@
              0             2             0             0             0             0        -99          0          0          0          0          0          0          0  #  AgeSpline_Code_Type27_age_cubic-spline_6
         -0.001            10       1.25246             0           0.1             0          3          0          0          0          0          0          0          0  #  AgeSpline_GradLo_Type27_age_cubic-spline_6
            -10          0.01             0             0           0.1             0         -3          0          0          0          0          0          0          0  #  AgeSpline_GradHi_Type27_age_cubic-spline_6
-             1            20           0.5             0             0             0        -99          0          0          0          0          0          0          0  #  AgeSpline_Knot_1_Type27_age_cubic-spline_6
+             0            20           0.5             0             0             0        -99          0          0          0          0          0          0          0  #  AgeSpline_Knot_1_Type27_age_cubic-spline_6
              1            20             7             0             0             0        -99          0          0          0          0          0          0          0  #  AgeSpline_Knot_2_Type27_age_cubic-spline_6
              1            20            15             0             0             0        -99          0          0          0          0          0          0          0  #  AgeSpline_Knot_3_Type27_age_cubic-spline_6
             -5             5      -4.99988             0             0             0          2          0          0          0          0          0          0          0  #  AgeSpline_Val_1_Type27_age_cubic-spline_6

--- a/model_files/selex_age_example/ss_summary.sso
+++ b/model_files/selex_age_example/ss_summary.sso
@@ -1,7 +1,7 @@
 #V3.30.22.00;_safe;_compile_date:_Oct 30 2023;_Stock_Synthesis_by_Richard_Methot_(NOAA)_using_ADMB_13.1
 selex_age_example_data.ss #_DataFile 
 selex_age_example_control.ss #_Control 
-Run_Date: Wed Nov  1 15:55:23 2023
+Run_Date: Tue Nov  7 12:14:04 2023
 Final_phase: 4  N_iterations: 173
 #_LIKELIHOOD 
 Label logL*Lambda
@@ -34,8 +34,8 @@ Mat50%_Fem_GP_1 55 0 Fix 0.5
 Mat_slope_Fem_GP_1 -0.25 0 Fix 0.458333
 Eggs/kg_inter_Fem_GP_1 1 0 Fix 0.666667
 Eggs/kg_slope_wt_Fem_GP_1 0 0 Fix 0.5
-NatM_uniform_Mal_GP_1 0.25 0 Fix 1.99998
-L_at_Amin_Mal_GP_1 0 0 Fix -0.0227273
+NatM_uniform_Mal_GP_1 0.25 0 Fix 0.799997
+L_at_Amin_Mal_GP_1 0 0 Fix 0
 L_at_Amax_Mal_GP_1 65 0 Fix 0.5
 VonBert_K_Mal_GP_1 0.24 0 Fix 0.949995
 CV_young_Mal_GP_1 0.1 0 Fix 0.249999
@@ -99,7 +99,7 @@ AgeSel_P3_Type25_age_exponential-logistic(5) 0.00100028 0.000215369 Act 4.65745e
 AgeSpline_Code_Type27_age_cubic-spline_6 0 0 Fix 0
 AgeSpline_GradLo_Type27_age_cubic-spline_6 1.25873 0.171216 Act 0.12596
 AgeSpline_GradHi_Type27_age_cubic-spline_6 0 0 Fix 0.999001
-AgeSpline_Knot_1_Type27_age_cubic-spline_6 0.5 0 Fix -0.0263158
+AgeSpline_Knot_1_Type27_age_cubic-spline_6 0.5 0 Fix 0.025
 AgeSpline_Knot_2_Type27_age_cubic-spline_6 7 0 Fix 0.315789
 AgeSpline_Knot_3_Type27_age_cubic-spline_6 15 0 Fix 0.736842
 AgeSpline_Val_1_Type27_age_cubic-spline_6 -4.99988 0.00697575 Act 1.20657e-05

--- a/model_files/selex_length_example/selex_length_example_control.ss
+++ b/model_files/selex_length_example/selex_length_example_control.ss
@@ -86,9 +86,9 @@
  -3 3 1 1 0.8 0 -3 0 0 0 0 0 0 0 # Eggs/kg_inter_Fem_GP_1
  -3 3 0 0 0.8 0 -3 0 0 0 0 0 0 0 # Eggs/kg_slope_wt_Fem_GP_1
 # Sex: 2  BioPattern: 1  NatMort
- 0.05 0.15 0.25 0.1 0.8 0 -3 0 0 0 0 0 0 0 # NatM_uniform_Mal_GP_1
+ 0.05 0.30 0.25 0.1 0.8 0 -3 0 0 0 0 0 0 0 # NatM_uniform_Mal_GP_1
 # Sex: 2  BioPattern: 1  Growth
- 1 45 0 36 10 0 -3 0 0 0 0 0 0 0 # L_at_Amin_Mal_GP_1
+ 0 45 0 36 10 0 -3 0 0 0 0 0 0 0 # L_at_Amin_Mal_GP_1
  40 90 65 70 10 6 -4 0 0 0 0 0 0 0 # L_at_Amax_Mal_GP_1
  0.05 0.25 0.24 0.15 0.8 6 -4 0 0 0 0 0 0 0 # VonBert_K_Mal_GP_1
  0.05 0.25 0.1 0.1 0.8 0 -3 0 0 0 0 0 0 0 # CV_young_Mal_GP_1

--- a/model_files/selex_length_example/ss_summary.sso
+++ b/model_files/selex_length_example/ss_summary.sso
@@ -1,7 +1,7 @@
 #V3.30.22.00;_safe;_compile_date:_Oct 30 2023;_Stock_Synthesis_by_Richard_Methot_(NOAA)_using_ADMB_13.1
 selex_length_example_data.ss #_DataFile 
 selex_length_example_control.ss #_Control 
-Run_Date: Wed Nov  1 16:07:44 2023
+Run_Date: Tue Nov  7 12:22:25 2023
 Final_phase: 4  N_iterations: 115
 #_LIKELIHOOD 
 Label logL*Lambda
@@ -34,8 +34,8 @@ Mat50%_Fem_GP_1 55 0 Fix 0.5
 Mat_slope_Fem_GP_1 -0.25 0 Fix 0.458333
 Eggs/kg_inter_Fem_GP_1 1 0 Fix 0.666667
 Eggs/kg_slope_wt_Fem_GP_1 0 0 Fix 0.5
-NatM_uniform_Mal_GP_1 0.25 0 Fix 1.99998
-L_at_Amin_Mal_GP_1 0 0 Fix -0.0227273
+NatM_uniform_Mal_GP_1 0.25 0 Fix 0.799997
+L_at_Amin_Mal_GP_1 0 0 Fix 0
 L_at_Amax_Mal_GP_1 65 0 Fix 0.5
 VonBert_K_Mal_GP_1 0.24 0 Fix 0.949995
 CV_young_Mal_GP_1 0.1 0 Fix 0.249999


### PR DESCRIPTION
See issue #30 to clean up warnings in user-example files. Warning files aren't kept for these models like they are for test models so used the text files in the issue to make changes.
